### PR TITLE
[CSVS-77] Simplify restore procedure geoserver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@ FROM python:3.7.8-alpine3.12
 
 RUN pip install awscli
 
+RUN apk update && apk upgrade && \
+    apk add curl
+
 ENTRYPOINT ["tail", "-f", "/dev/null"]
 
 ENV AWS_ACCESS_KEY_ID **None**
@@ -12,3 +15,4 @@ ENV S3_URL http://s3-uk-1.sa-catapult.co.uk
 
 COPY restore_rasters.sh /restore_rasters.sh
 COPY restore_netcdf.sh /restore_netcdf.sh
+COPY restore_backup.sh /restore_backup.sh

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-IMAGENAME = satapps/geoserver-commands:0.6
+IMAGENAME = satapps/geoserver-commands:0.7
 
 build:
 	docker build -t $(IMAGENAME) .

--- a/restore_backup.sh
+++ b/restore_backup.sh
@@ -1,0 +1,29 @@
+BACKUP_FILE=$1
+ADMIN_PASS=$2
+
+if [[ -z "$BACKUP_FILE" ]] ; then
+    echo 'Please, provide backup file name as an argument.'
+else
+    if [ -z "$ADMIN_PASS" ] ; then
+        ADMIN_PASS=geoserver
+    fi
+
+    # Download backup file from S3 bucket
+    aws --endpoint-url=$S3_URL s3 cp s3://csvs-backups/$BACKUP_FILE .
+    # Execute restore if file exists and it is downloaded
+    if [ $? -eq 0 ]; then
+        echo starting restore from backup file $BACKUP_FILE &&
+        mkdir -p /geoserver_data/data/backup_unzipped &&
+        mv $BACKUP_FILE tmp.tgz
+        tar -xvzf tmp.tgz -C /geoserver_data/data/backup_unzipped &&
+        cp -r /geoserver_data/data/backup_unzipped/geoserver_data/data/* /geoserver_data/data/ &&
+        echo copying files from abckup to data folder 
+        curl -u admin:$ADMIN_PASS -X POST http://geoserver:8080/geoserver/rest/reset -I
+        curl -u admin:$ADMIN_PASS -X PUT http://geoserver:8080/geoserver/rest/reload -I
+        echo removing tmp files
+        rm -rf /geoserver_data/data/backup_unzipped
+        echo configuration restored
+    else
+        echo 'Failed trying to download the backup file.'
+    fi
+fi

--- a/restore_backup.sh
+++ b/restore_backup.sh
@@ -11,20 +11,28 @@ if [ -z "$GEOSERVER_CRED" ] ; then
 fi
 
 {
-    # Download backup file from S3 bucket
+    curl -f -u $GEOSERVER_CRED -X GET http://geoserver:8080/geoserver/rest/reset -I
+} || {
+    echo 'The provided credentials are not valid.'
+    exit 2
+}
+
+{
     aws --endpoint-url=$S3_URL s3 cp s3://csvs-backups/$BACKUP_FILE .
-    # Start restore process
-    echo Starting restore from backup file $BACKUP_FILE &&
-    mkdir -p /geoserver_data/data/backup_unzipped &&
-    mv $BACKUP_FILE tmp.tgz
-    tar -xvzf tmp.tgz -C /geoserver_data/data/backup_unzipped &&
-    cp -r /geoserver_data/data/backup_unzipped/geoserver_data/data/* /geoserver_data/data/ &&
-    echo copying files from abckup to data folder
-    curl -u $GEOSERVER_CRED -X POST http://geoserver:8080/geoserver/rest/reset -I
-    curl -u $GEOSERVER_CRED -X PUT http://geoserver:8080/geoserver/rest/reload -I
-    echo removing tmp files
-    rm -rf /geoserver_data/data/backup_unzipped
-    echo configuration restored
 } || {
     echo 'Failed trying to download the backup file.'
+    exit 2
 }
+
+# Start restore process
+echo Starting restore from backup file $BACKUP_FILE &&
+mkdir -p /geoserver_data/data/backup_unzipped &&
+mv $BACKUP_FILE tmp.tgz
+tar -xvzf tmp.tgz -C /geoserver_data/data/backup_unzipped &&
+cp -r /geoserver_data/data/backup_unzipped/geoserver_data/data/* /geoserver_data/data/ &&
+echo copying files from abckup to data folder
+curl -u $GEOSERVER_CRED -X POST http://geoserver:8080/geoserver/rest/reset -I
+curl -u $GEOSERVER_CRED -X PUT http://geoserver:8080/geoserver/rest/reload -I
+echo removing tmp files
+rm -rf /geoserver_data/data/backup_unzipped
+echo configuration restored

--- a/restore_backup.sh
+++ b/restore_backup.sh
@@ -1,29 +1,30 @@
 BACKUP_FILE=$1
-ADMIN_PASS=$2
+GEOSERVER_CRED=$2
 
 if [[ -z "$BACKUP_FILE" ]] ; then
     echo 'Please, provide backup file name as an argument.'
-else
-    if [ -z "$ADMIN_PASS" ] ; then
-        ADMIN_PASS=geoserver
-    fi
+    exit 2
+fi
 
+if [ -z "$GEOSERVER_CRED" ] ; then
+    GEOSERVER_CRED=admin:geoserver
+fi
+
+{
     # Download backup file from S3 bucket
     aws --endpoint-url=$S3_URL s3 cp s3://csvs-backups/$BACKUP_FILE .
-    # Execute restore if file exists and it is downloaded
-    if [ $? -eq 0 ]; then
-        echo starting restore from backup file $BACKUP_FILE &&
-        mkdir -p /geoserver_data/data/backup_unzipped &&
-        mv $BACKUP_FILE tmp.tgz
-        tar -xvzf tmp.tgz -C /geoserver_data/data/backup_unzipped &&
-        cp -r /geoserver_data/data/backup_unzipped/geoserver_data/data/* /geoserver_data/data/ &&
-        echo copying files from abckup to data folder 
-        curl -u admin:$ADMIN_PASS -X POST http://geoserver:8080/geoserver/rest/reset -I
-        curl -u admin:$ADMIN_PASS -X PUT http://geoserver:8080/geoserver/rest/reload -I
-        echo removing tmp files
-        rm -rf /geoserver_data/data/backup_unzipped
-        echo configuration restored
-    else
-        echo 'Failed trying to download the backup file.'
-    fi
-fi
+    # Start restore process
+    echo Starting restore from backup file $BACKUP_FILE &&
+    mkdir -p /geoserver_data/data/backup_unzipped &&
+    mv $BACKUP_FILE tmp.tgz
+    tar -xvzf tmp.tgz -C /geoserver_data/data/backup_unzipped &&
+    cp -r /geoserver_data/data/backup_unzipped/geoserver_data/data/* /geoserver_data/data/ &&
+    echo copying files from abckup to data folder
+    curl -u $GEOSERVER_CRED -X POST http://geoserver:8080/geoserver/rest/reset -I
+    curl -u $GEOSERVER_CRED -X PUT http://geoserver:8080/geoserver/rest/reload -I
+    echo removing tmp files
+    rm -rf /geoserver_data/data/backup_unzipped
+    echo configuration restored
+} || {
+    echo 'Failed trying to download the backup file.'
+}

--- a/restore_backup.sh
+++ b/restore_backup.sh
@@ -11,7 +11,7 @@ if [ -z "$GEOSERVER_CRED" ] ; then
 fi
 
 {
-    curl -f -u $GEOSERVER_CRED -X GET http://geoserver:8080/geoserver/rest/reset -I
+    curl -f -u $GEOSERVER_CRED -X POST http://geoserver:8080/geoserver/rest/reset -I
 } || {
     echo 'The provided credentials are not valid.'
     exit 2
@@ -31,7 +31,6 @@ mv $BACKUP_FILE tmp.tgz
 tar -xvzf tmp.tgz -C /geoserver_data/data/backup_unzipped &&
 cp -r /geoserver_data/data/backup_unzipped/geoserver_data/data/* /geoserver_data/data/ &&
 echo copying files from abckup to data folder
-curl -u $GEOSERVER_CRED -X POST http://geoserver:8080/geoserver/rest/reset -I
 curl -u $GEOSERVER_CRED -X PUT http://geoserver:8080/geoserver/rest/reload -I
 echo removing tmp files
 rm -rf /geoserver_data/data/backup_unzipped


### PR DESCRIPTION
To execute script from sidecar container:

```
# kubectl -n <your namespace> exec <geoserver pod> -c geoserver-sidecar -it -- sh /restore_backup.sh <backup file name> <geoserver_user:geoserver_pass>
```

If `<admin password>` is left blank the default password would be used. This only works when restoring geoserver after a clean installation. When a geoserver instance is already deployed and a new admin password has been set up, use this argument with it.

Example:

```
# kubectl -n dev-csvs exec geoserver-cf479c5d9-rn2pr -c geoserver-sidecar -it -- sh restore_backup.sh dev-csvs_geoserver_config_backup_2020-08-14T00:00:09Z.tgz 'user:geoserver'
```